### PR TITLE
Fix Artifacts upload in CI config

### DIFF
--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -52,5 +52,5 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: "Heartry-v${{ env.APP_VERSION }}.apk"
+        name: "Heartry-nightly-v${{ env.APP_VERSION }}.apk"
         path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -46,12 +46,12 @@ jobs:
       run: |
         flutter build apk --debug
 
-    #    VERSION="v$(grep "flutter.versionName" android/local.properties | cut -d = -f 2)"
-    #    cp build/app/outputs/flutter-apk/app-release.apk "./Heartry-${VERSION}.apk"
+        VERSION="v$(grep "flutter.versionName" android/local.properties | cut -d = -f 2)"
+        cp build/app/outputs/flutter-apk/app-debug.apk "./Heartry-${VERSION}.apk"
 
-    #   echo "Built apk for ${VERSION}"
+        echo "Built apk for ${VERSION}"
 
-  #  - uses: actions/upload-artifact@v2
-  #    with:
-  #      name: debug-apk
-  #      path: "*.apk"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: debug-apk
+        path: "*.apk"

--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     paths:
+      - ".github/workflows/**"
       - "lib/**"
       - "android/**"
       - "ios/**"
@@ -31,6 +32,8 @@ jobs:
 
     - name: Setup project
       run: |
+        echo "APP_VERSION=$(grep -Po '(?<=version: )(.*)(?=\+)' pubspec.yaml)" >> $GITHUB_ENV
+
         flutter pub get
         flutter pub run build_runner build
 
@@ -45,13 +48,9 @@ jobs:
     - name: Build debug apk
       run: |
         flutter build apk --debug
-
-        VERSION="v$(grep "flutter.versionName" android/local.properties | cut -d = -f 2)"
-        cp build/app/outputs/flutter-apk/app-debug.apk "./Heartry-${VERSION}.apk"
-
-        echo "Built apk for ${VERSION}"
+        echo "Built apk for version ${APP_VERSION}"
 
     - uses: actions/upload-artifact@v2
       with:
-        name: debug-apk
-        path: "*.apk"
+        name: "Heartry-v${{ env.APP_VERSION }}.apk"
+        path: build/app/outputs/flutter-apk/app-debug.apk


### PR DESCRIPTION
- Changing `app-release.apk` to `app-debug.apk` fixes the issue.
- Fixes artifact naming to `Heartry-v{APP_VERSION}.apk`

Successful run: https://github.com/KartikSoneji/Heartry/actions/runs/525558702